### PR TITLE
Shorten unnecessary code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-const {Plugin} = require('powercord/entities');
+const { Plugin } = require('powercord/entities');
 
-
-module.exports = class shake extends Plugin {
+module.exports = class Shake extends Plugin {
 	startPlugin() {
-
 		powercord.api.commands.registerCommand({
 			command: 'shake',
 			description: 'Shakes your screen',
@@ -19,37 +17,22 @@ module.exports = class shake extends Plugin {
 						commands: [{
 							command: "Enter how long you want the screen to shake for",
 							instruction: true,
-						}, ],
+						}],
 					};
 				}
-
 			}
-
 		});
-
 	}
+	
 	pluginWillUnload() {
 		powercord.api.commands.unregisterCommand('shake');
 	}
 
-
-
-
-
-
-
 	generateShake(args) {
-		if (args.length === 0) return require('powercord/webpack').getModule(['ComponentDispatch'], false).ComponentDispatch.dispatch('SHAKE_APP', {
-			duration: 200,
-			intensity: 2
-		})
 		//thanks to Juby210 for helping me find this module
 		require('powercord/webpack').getModule(['ComponentDispatch'], false).ComponentDispatch.dispatch('SHAKE_APP', {
-			duration: args[0] * 1000,
+			duration: args.length && !isNaN(parseInt(args[0])) ? args[0] * 1000 : 200,
 			intensity: 2
-		})
-
-
+		});
 	}
-
 };


### PR DESCRIPTION
Make code use JavaScript code conventions (e.g. class names should be PascalCase), and remove the random newlines everywhere.